### PR TITLE
Hide wrongly displayed "Hide" button on main page

### DIFF
--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -531,6 +531,16 @@ export class EventsDisplay extends LitElement implements Layer {
   }
 
   render() {
+    if (
+      this.events.length === 0 &&
+      this.incomingAttacks.length === 0 &&
+      this.outgoingAttacks.length === 0 &&
+      this.outgoingLandAttacks.length === 0 &&
+      this.outgoingBoats.length === 0
+    ) {
+      return html``;
+    }
+    
     this.events.sort((a, b) => {
       const aPrior = a.priority ?? 100000;
       const bPrior = b.priority ?? 100000;


### PR DESCRIPTION
## Description:
A previous commit made the "Hide" button of the event log visible on the main page. This hides it again, as before.

![image](https://github.com/user-attachments/assets/f8182944-5f6a-451b-acb5-18dbc4331b72)


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
jacks0n
